### PR TITLE
Fix Typo task to uploadTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ let fileURL: URL // Upload file
 let uploadTask = reference.putFile(from: fileURL)
 
 // Listen for state changes
-task.rx.observe(.progress)
+uploadTask.rx.observe(.progress)
     .subscribe(onNext: { snapshot in
         // Upload reported progress
         let percentComplete = 100.0 * Double(snapshot.progress!.completedUnitCount)


### PR DESCRIPTION
Fix typo "task" to "uploadTask"

I think it can occur confusion