### PR TITLE
Update Firebase depedencies to version 7

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,8 @@
 use_frameworks!
 
 target 'RxFirebase_Example' do
+  platform :ios, '10.0'
+
   pod 'RxFirebase/Storage', :path => './'
   pod 'RxFirebase/Firestore', :path => './'
   pod 'RxFirebase/RemoteConfig', :path => './'
@@ -18,6 +20,8 @@ target 'RxFirebase_Example' do
 end
 
 target 'RxFirebase_Example_tvOS' do
+  platform :tvos, '10.0'
+
   pod 'RxFirebaseStorage', :path => './'
   pod 'RxFirebaseDatabase', :path => './'
   pod 'RxFirebaseAuthentication', :path => './'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -218,35 +218,26 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.7):
     - BoringSSL-GRPC/Interface (= 0.0.7)
   - BoringSSL-GRPC/Interface (0.0.7)
-  - FirebaseABTesting (3.2.0):
-    - FirebaseAnalyticsInterop (~> 1.3)
-    - FirebaseCore (~> 6.1)
-    - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseAnalyticsInterop (1.5.0)
-  - FirebaseAuth (6.5.3):
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.6)
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
-    - GoogleUtilities/Environment (~> 6.5)
-    - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseAuthInterop (1.1.0)
-  - FirebaseCore (6.7.0):
-    - FirebaseCoreDiagnostics (~> 1.3)
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
-    - GoogleUtilities/Environment (~> 6.5)
-    - GoogleUtilities/Logger (~> 6.5)
-  - FirebaseCoreDiagnostics (1.3.0):
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
-    - GoogleDataTransportCCTSupport (~> 3.1)
-    - GoogleUtilities/Environment (~> 6.5)
-    - GoogleUtilities/Logger (~> 6.5)
-    - nanopb (~> 1.30905.0)
-  - FirebaseCoreDiagnosticsInterop (1.2.0)
-  - FirebaseDatabase (6.2.1):
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.0)
+  - FirebaseABTesting (7.2.0):
+    - FirebaseCore (~> 7.0)
+  - FirebaseAuth (7.2.0):
+    - FirebaseCore (~> 7.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GTMSessionFetcher/Core (~> 1.4)
+  - FirebaseCore (7.2.0):
+    - FirebaseCoreDiagnostics (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Logger (~> 7.0)
+  - FirebaseCoreDiagnostics (7.2.0):
+    - GoogleDataTransport (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/Logger (~> 7.0)
+    - nanopb (~> 2.30906.0)
+  - FirebaseDatabase (7.2.0):
+    - FirebaseCore (~> 7.0)
     - leveldb-library (~> 1.22)
-  - FirebaseFirestore (1.13.0):
+  - FirebaseFirestore (7.2.0):
     - abseil/algorithm (= 0.20200225.0)
     - abseil/base (= 0.20200225.0)
     - abseil/memory (= 0.20200225.0)
@@ -254,86 +245,78 @@ PODS:
     - abseil/strings/strings (= 0.20200225.0)
     - abseil/time (= 0.20200225.0)
     - abseil/types (= 0.20200225.0)
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.2)
+    - FirebaseCore (~> 7.0)
     - "gRPC-C++ (~> 1.28.0)"
     - leveldb-library (~> 1.22)
-    - nanopb (~> 1.30905.0)
-  - FirebaseFunctions (2.5.1):
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.0)
-    - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseInstallations (1.2.0):
-    - FirebaseCore (~> 6.6)
-    - GoogleUtilities/Environment (~> 6.6)
-    - GoogleUtilities/UserDefaults (~> 6.6)
+    - nanopb (~> 2.30906.0)
+  - FirebaseFunctions (7.2.0):
+    - FirebaseCore (~> 7.0)
+    - GTMSessionFetcher/Core (~> 1.4)
+  - FirebaseInstallations (7.2.0):
+    - FirebaseCore (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseRemoteConfig (4.4.10):
-    - FirebaseABTesting (~> 3.1)
-    - FirebaseAnalyticsInterop (~> 1.4)
-    - FirebaseCore (~> 6.2)
-    - FirebaseInstallations (~> 1.1)
-    - GoogleUtilities/Environment (~> 6.2)
-    - "GoogleUtilities/NSData+zlib (~> 6.2)"
-    - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseStorage (3.6.1):
-    - FirebaseAuthInterop (~> 1.1)
-    - FirebaseCore (~> 6.6)
-    - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleDataTransport (6.1.0)
-  - GoogleDataTransportCCTSupport (3.1.0):
-    - GoogleDataTransport (~> 6.1)
-    - nanopb (~> 1.30905.0)
-  - GoogleUtilities/AppDelegateSwizzler (6.6.0):
+  - FirebaseRemoteConfig (7.2.0):
+    - FirebaseABTesting (~> 7.0)
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleUtilities/Environment (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+  - FirebaseStorage (7.2.0):
+    - FirebaseCore (~> 7.0)
+    - GTMSessionFetcher/Core (~> 1.4)
+  - GoogleDataTransport (8.0.1):
+    - nanopb (~> 2.30906.0)
+  - GoogleUtilities/AppDelegateSwizzler (7.1.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.6.0):
+  - GoogleUtilities/Environment (7.1.1):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.6.0):
+  - GoogleUtilities/Logger (7.1.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (6.6.0):
+  - GoogleUtilities/Network (7.1.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.6.0)"
-  - GoogleUtilities/Reachability (6.6.0):
+  - "GoogleUtilities/NSData+zlib (7.1.1)"
+  - GoogleUtilities/Reachability (7.1.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (6.6.0):
+  - GoogleUtilities/UserDefaults (7.1.1):
     - GoogleUtilities/Logger
-  - "gRPC-C++ (1.28.0)":
-    - "gRPC-C++/Implementation (= 1.28.0)"
-    - "gRPC-C++/Interface (= 1.28.0)"
-  - "gRPC-C++/Implementation (1.28.0)":
+  - "gRPC-C++ (1.28.2)":
+    - "gRPC-C++/Implementation (= 1.28.2)"
+    - "gRPC-C++/Interface (= 1.28.2)"
+  - "gRPC-C++/Implementation (1.28.2)":
     - abseil/container/inlined_vector (= 0.20200225.0)
     - abseil/memory/memory (= 0.20200225.0)
     - abseil/strings/str_format (= 0.20200225.0)
     - abseil/strings/strings (= 0.20200225.0)
     - abseil/types/optional (= 0.20200225.0)
-    - "gRPC-C++/Interface (= 1.28.0)"
-    - gRPC-Core (= 1.28.0)
-  - "gRPC-C++/Interface (1.28.0)"
-  - gRPC-Core (1.28.0):
-    - gRPC-Core/Implementation (= 1.28.0)
-    - gRPC-Core/Interface (= 1.28.0)
-  - gRPC-Core/Implementation (1.28.0):
+    - "gRPC-C++/Interface (= 1.28.2)"
+    - gRPC-Core (= 1.28.2)
+  - "gRPC-C++/Interface (1.28.2)"
+  - gRPC-Core (1.28.2):
+    - gRPC-Core/Implementation (= 1.28.2)
+    - gRPC-Core/Interface (= 1.28.2)
+  - gRPC-Core/Implementation (1.28.2):
     - abseil/container/inlined_vector (= 0.20200225.0)
     - abseil/memory/memory (= 0.20200225.0)
     - abseil/strings/str_format (= 0.20200225.0)
     - abseil/strings/strings (= 0.20200225.0)
     - abseil/types/optional (= 0.20200225.0)
     - BoringSSL-GRPC (= 0.0.7)
-    - gRPC-Core/Interface (= 1.28.0)
-  - gRPC-Core/Interface (1.28.0)
-  - GTMSessionFetcher/Core (1.4.0)
+    - gRPC-Core/Interface (= 1.28.2)
+  - gRPC-Core/Interface (1.28.2)
+  - GTMSessionFetcher/Core (1.5.0)
   - leveldb-library (1.22)
-  - nanopb (1.30905.0):
-    - nanopb/decode (= 1.30905.0)
-    - nanopb/encode (= 1.30905.0)
-  - nanopb/decode (1.30905.0)
-  - nanopb/encode (1.30905.0)
-  - PromisesObjC (1.2.8)
-  - Protobuf (3.11.4)
+  - nanopb (2.30906.0):
+    - nanopb/decode (= 2.30906.0)
+    - nanopb/encode (= 2.30906.0)
+  - nanopb/decode (2.30906.0)
+  - nanopb/encode (2.30906.0)
+  - PromisesObjC (1.2.11)
   - RxCocoa (5.1.1):
     - RxRelay (~> 5)
     - RxSwift (~> 5)
@@ -350,28 +333,28 @@ PODS:
   - RxFirebase/Storage (0.3.8):
     - RxFirebaseStorage (~> 0.3)
   - RxFirebaseAuthentication (0.3.8):
-    - FirebaseAuth (~> 6)
-    - FirebaseCore (~> 6)
+    - FirebaseAuth (~> 7)
+    - FirebaseCore (~> 7)
     - RxCocoa (~> 5)
     - RxSwift (~> 5)
   - RxFirebaseDatabase (0.3.8):
-    - FirebaseDatabase (~> 6)
+    - FirebaseDatabase (~> 7)
     - RxCocoa (~> 5)
     - RxSwift (~> 5)
   - RxFirebaseFirestore (0.3.8):
-    - FirebaseFirestore (~> 1.5)
+    - FirebaseFirestore (~> 7)
     - RxCocoa (~> 5)
     - RxSwift (~> 5)
   - RxFirebaseFunctions (0.3.8):
-    - FirebaseFunctions (~> 2.5)
+    - FirebaseFunctions (~> 7)
     - RxCocoa (~> 5)
     - RxSwift (~> 5)
   - RxFirebaseRemoteConfig (0.3.8):
-    - FirebaseRemoteConfig (~> 4)
+    - FirebaseRemoteConfig (~> 7)
     - RxCocoa (~> 5)
     - RxSwift (~> 5)
   - RxFirebaseStorage (0.3.8):
-    - FirebaseStorage (~> 3)
+    - FirebaseStorage (~> 7)
     - RxCocoa (~> 5)
     - RxSwift (~> 5)
   - RxRelay (5.1.1):
@@ -397,12 +380,9 @@ SPEC REPOS:
     - abseil
     - BoringSSL-GRPC
     - FirebaseABTesting
-    - FirebaseAnalyticsInterop
     - FirebaseAuth
-    - FirebaseAuthInterop
     - FirebaseCore
     - FirebaseCoreDiagnostics
-    - FirebaseCoreDiagnosticsInterop
     - FirebaseDatabase
     - FirebaseFirestore
     - FirebaseFunctions
@@ -410,7 +390,6 @@ SPEC REPOS:
     - FirebaseRemoteConfig
     - FirebaseStorage
     - GoogleDataTransport
-    - GoogleDataTransportCCTSupport
     - GoogleUtilities
     - "gRPC-C++"
     - gRPC-Core
@@ -418,7 +397,6 @@ SPEC REPOS:
     - leveldb-library
     - nanopb
     - PromisesObjC
-    - Protobuf
     - RxCocoa
     - RxRelay
     - RxSwift
@@ -442,40 +420,35 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   abseil: 6c8eb7892aefa08d929b39f9bb108e5367e3228f
   BoringSSL-GRPC: 8edf627ee524575e2f8d19d56f068b448eea3879
-  FirebaseABTesting: 821a3a3e4a145987e80fee3657c4de1cb9adf693
-  FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
-  FirebaseAuth: 7047aec89c0b17ecd924a550c853f0c27ac6015e
-  FirebaseAuthInterop: a0f37ae05833af156e72028f648d313f7e7592e9
-  FirebaseCore: e610482f64097b0e9f056cd97bc6b33dfabcbb6a
-  FirebaseCoreDiagnostics: 4a773a47bd83bbd5a9b1ccf1ce7caa8b2d535e67
-  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
-  FirebaseDatabase: 4e99c0c475d1ee0aa64ae2b53c93f80b7b60d7d9
-  FirebaseFirestore: 35f8f67d7b25e4743c62ea6e46c38cafa8dc32b5
-  FirebaseFunctions: 5af7c35d1c5e41608fecbb667eb6c4e672e318d0
-  FirebaseInstallations: 2119fb3e46b0a88bfdbf12562f855ee3252462fa
-  FirebaseRemoteConfig: 12669ca87e6d9cf87a6123cb8ad8a771a7b49c6b
-  FirebaseStorage: f4f39ae834a7145963b913f54e2f24a9db1d8fac
-  GoogleDataTransport: f6f8eba931df03ebd2232ff4645aa85f8f47b5ab
-  GoogleDataTransportCCTSupport: d70a561f7d236af529fee598835caad5e25f6d3d
-  GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
-  "gRPC-C++": 2ea13a2e14f0b89991a0b4b0151e7c6a56319516
-  gRPC-Core: 325ba201411619a7302c621a1c8ee787719d4b9b
-  GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
+  FirebaseABTesting: 55ed7b94464eee98180d91131f3c85e554ae243d
+  FirebaseAuth: e6a214cc897d2eab7635b1e5dd6b4298fd1e776b
+  FirebaseCore: c959e8a598f83125c01c1700d9161b236ab3833c
+  FirebaseCoreDiagnostics: 2d508e12e77e9691ca67d1669b91ee80f0985b29
+  FirebaseDatabase: efb4d986413f55f7d9a05e621bd86ca1589e6ca7
+  FirebaseFirestore: 526c70e247f550206e5c02a7bafc264588847499
+  FirebaseFunctions: 64d08fe979f2c5b38cb80f19ed99bbe08e952708
+  FirebaseInstallations: 9ab3a9a6522e687f59ff9bcfd92949ac85073f3c
+  FirebaseRemoteConfig: 73cad38920c491ea81c5c66f9e94a87f265b85a4
+  FirebaseStorage: 4c2cdd98dfe5f6b3fae02db0da72105ac5554bbd
+  GoogleDataTransport: e4085e6762f36a6141738f46b0153473ce57fb18
+  GoogleUtilities: 3dc4ff0d5e4840e2fa8eef0889620e8c33d4218c
+  "gRPC-C++": 13d8ccef97d5c3c441b7e3c529ef28ebee86fad2
+  gRPC-Core: 4afa11bfbedf7cdecd04de535a9e046893404ed5
+  GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
-  nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
-  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
-  Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
+  nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
+  PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
   RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
-  RxFirebase: 45e6448c69c7212e21f8ba89144443f916437861
-  RxFirebaseAuthentication: 5d0573fd641947ed857346624d1c849bbd86bdff
-  RxFirebaseDatabase: 5c1d3d31c9858f05ff6ad92e5b4b696354d1497b
-  RxFirebaseFirestore: edabc5e6b02bd876a323a0e53cb5071356505db2
-  RxFirebaseFunctions: c32622f9bb7c75c01a2489a38e376b5038e2d6f3
-  RxFirebaseRemoteConfig: 0ed07be283650b572cb07bb8b940f08546c4b792
-  RxFirebaseStorage: 271184ff8f8d3660bfc751dcafdbb4dd01d0b8a1
+  RxFirebase: 4c80f346f8d43fcd5fe40b61a84d93b5dc8b0e55
+  RxFirebaseAuthentication: b40174bf57fbbbf8157192396ecdba4b354b478a
+  RxFirebaseDatabase: 97e4cc6dc40aac6215cfe90a55398c841c8d9081
+  RxFirebaseFirestore: ecd6f2550ac4178a532e520b2021cede19000e45
+  RxFirebaseFunctions: 0fea59596122baa7501514f20454b0ba2f070445
+  RxFirebaseRemoteConfig: 86ccb53b8d590cdf1f82cf3cb336bbe556a2a375
+  RxFirebaseStorage: 2c6207c6a057945836b81f989b76bb5cd98edcab
   RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
   RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
 
-PODFILE CHECKSUM: 6b5209972f53f589215fcd40d8892f3d937408a6
+PODFILE CHECKSUM: 191ff931ea02436382fc98ed819d055b400e4a3c
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.0

--- a/RxFirebase.podspec
+++ b/RxFirebase.podspec
@@ -10,26 +10,26 @@ Pod::Spec.new do |s|
     s.name             = 'RxFirebase'
     s.version          = '0.3.8'
     s.summary          = 'RxSwift extensions for Firebase.'
-    
+
     # This description is used to generate tags and improve search results.
     #   * Think: What does it do? Why did you write it? What is the focus?
     #   * Try to keep it short, snappy and to the point.
     #   * Write the description between the DESC delimiters below.
     #   * Finally, don't worry about the indent, CocoaPods strips it!
-    
+
     s.description      = <<-DESC
     RxSwift extensions for Firebase.
     Including for now Database, Firestore, RemoteConfig, Storage, Functions, Auth
     DESC
-    
+
     s.homepage         = 'https://github.com/RxSwiftCommunity/RxFirebase'
     # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Arnaud Dorgans' => 'arnaud.dorgans@gmail.com' }
     s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxFirebase.git', :tag => s.version.to_s }
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.11'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
     s.static_framework = true
     s.swift_versions = '5.0'

--- a/RxFirebase.xcodeproj/project.pbxproj
+++ b/RxFirebase.xcodeproj/project.pbxproj
@@ -335,10 +335,20 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RxFirebase_Example/Pods-RxFirebase_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/BoringSSL-GRPC/openssl_grpc.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseABTesting/FirebaseABTesting.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseAuth-iOS/FirebaseAuth.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCore-iOS/FirebaseCore.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCoreDiagnostics-iOS/FirebaseCoreDiagnostics.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseDatabase-iOS/FirebaseDatabase.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseFirestore/FirebaseFirestore.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseFunctions/FirebaseFunctions.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseInstallations/FirebaseInstallations.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseRemoteConfig/FirebaseRemoteConfig.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseStorage-iOS/FirebaseStorage.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher-iOS/GTMSessionFetcher.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleDataTransport-iOS/GoogleDataTransport.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities-54e75ca4/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/PromisesObjC-iOS/FBLPromises.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa-iOS/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxRelay-iOS/RxRelay.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift-iOS/RxSwift.framework",
@@ -351,10 +361,20 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/openssl_grpc.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseABTesting.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseAuth.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreDiagnostics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseDatabase.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseFirestore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseFunctions.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseInstallations.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseRemoteConfig.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseStorage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleDataTransport.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRelay.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
@@ -376,7 +396,13 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RxFirebase_Example_tvOS/Pods-RxFirebase_Example_tvOS-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/FirebaseAuth-tvOS/FirebaseAuth.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCore-tvOS/FirebaseCore.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCoreDiagnostics-tvOS/FirebaseCoreDiagnostics.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseDatabase-tvOS/FirebaseDatabase.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseStorage-tvOS/FirebaseStorage.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher-tvOS/GTMSessionFetcher.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleDataTransport-tvOS/GoogleDataTransport.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities-df6f21d7/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/PromisesObjC-tvOS/FBLPromises.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa-tvOS/RxCocoa.framework",
@@ -387,7 +413,13 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseAuth.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreDiagnostics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseDatabase.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseStorage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleDataTransport.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
@@ -563,6 +595,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -578,6 +611,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";

--- a/RxFirebaseAuthentication.podspec
+++ b/RxFirebaseAuthentication.podspec
@@ -2,34 +2,34 @@ Pod::Spec.new do |s|
     s.name             = 'RxFirebaseAuthentication'
     s.version          = '0.3.8'
     s.summary          = 'RxSwift extensions for FirebaseAuth.'
-    
+
     # This description is used to generate tags and improve search results.
     #   * Think: What does it do? Why did you write it? What is the focus?
     #   * Try to keep it short, snappy and to the point.
     #   * Write the description between the DESC delimiters below.
     #   * Finally, don't worry about the indent, CocoaPods strips it!
-    
+
     s.description      = <<-DESC
     RxSwift extensions for FirebaseAuth.
     DESC
-    
+
     s.homepage         = 'https://github.com/RxSwiftCommunity/RxFirebase'
     # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Arnaud Dorgans' => 'arnaud.dorgans@gmail.com' }
     s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxFirebase.git', :tag => s.version.to_s }
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
-    
-    s.cocoapods_version = '>= 1.4.0'
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.11'
+
+    s.cocoapods_version = '>= 1.10.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
 
     s.static_framework = true
     s.dependency 'RxSwift', '~> 5'
     s.dependency 'RxCocoa', '~> 5'
-    s.dependency 'FirebaseAuth', '~> 6'
-    s.dependency 'FirebaseCore', '~> 6'
+    s.dependency 'FirebaseAuth', '~> 7'
+    s.dependency 'FirebaseCore', '~> 7'
 
     s.source_files = 'Sources/Auth/**/*'
 end

--- a/RxFirebaseDatabase.podspec
+++ b/RxFirebaseDatabase.podspec
@@ -2,33 +2,33 @@ Pod::Spec.new do |s|
     s.name             = 'RxFirebaseDatabase'
     s.version          = '0.3.8'
     s.summary          = 'RxSwift extensions for FirebaseDatabase.'
-    
+
     # This description is used to generate tags and improve search results.
     #   * Think: What does it do? Why did you write it? What is the focus?
     #   * Try to keep it short, snappy and to the point.
     #   * Write the description between the DESC delimiters below.
     #   * Finally, don't worry about the indent, CocoaPods strips it!
-    
+
     s.description      = <<-DESC
     RxSwift extensions for RxFirebaseDatabase.
     DESC
-    
+
     s.homepage         = 'https://github.com/RxSwiftCommunity/RxFirebase'
     # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Arnaud Dorgans' => 'arnaud.dorgans@gmail.com' }
     s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxFirebase.git', :tag => s.version.to_s }
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
-    
-    s.cocoapods_version = '>= 1.4.0'
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.11'
+
+    s.cocoapods_version = '>= 1.10.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
 
     s.static_framework = true
     s.dependency 'RxSwift', '~> 5'
     s.dependency 'RxCocoa', '~> 5'
-    s.dependency 'FirebaseDatabase', '~> 6'
+    s.dependency 'FirebaseDatabase', '~> 7'
 
     s.source_files = 'Sources/Database/**/*'
 end

--- a/RxFirebaseFirestore.podspec
+++ b/RxFirebaseFirestore.podspec
@@ -2,33 +2,33 @@ Pod::Spec.new do |s|
     s.name             = 'RxFirebaseFirestore'
     s.version          = '0.3.8'
     s.summary          = 'RxSwift extensions for FirebaseFirestore.'
-    
+
     # This description is used to generate tags and improve search results.
     #   * Think: What does it do? Why did you write it? What is the focus?
     #   * Try to keep it short, snappy and to the point.
     #   * Write the description between the DESC delimiters below.
     #   * Finally, don't worry about the indent, CocoaPods strips it!
-    
+
     s.description      = <<-DESC
     RxSwift extensions for FirebaseFirestore.
     DESC
-    
+
     s.homepage         = 'https://github.com/RxSwiftCommunity/RxFirebase'
     # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Arnaud Dorgans' => 'arnaud.dorgans@gmail.com' }
     s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxFirebase.git', :tag => s.version.to_s }
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
-    
-    s.cocoapods_version = '>= 1.4.0'
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.11'
+
+    s.cocoapods_version = '>= 1.10.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
 
     s.static_framework = true
     s.dependency 'RxSwift', '~> 5'
     s.dependency 'RxCocoa', '~> 5'
-    s.dependency 'FirebaseFirestore', '~> 1.1'
+    s.dependency 'FirebaseFirestore', '~> 7'
 
     s.source_files = 'Sources/Firestore/**/*'
 end

--- a/RxFirebaseFunctions.podspec
+++ b/RxFirebaseFunctions.podspec
@@ -2,33 +2,33 @@ Pod::Spec.new do |s|
     s.name             = 'RxFirebaseFunctions'
     s.version          = '0.3.8'
     s.summary          = 'RxSwift extensions for FirebaseFunctions.'
-    
+
     # This description is used to generate tags and improve search results.
     #   * Think: What does it do? Why did you write it? What is the focus?
     #   * Try to keep it short, snappy and to the point.
     #   * Write the description between the DESC delimiters below.
     #   * Finally, don't worry about the indent, CocoaPods strips it!
-    
+
     s.description      = <<-DESC
     RxSwift extensions for FirebaseFunctions.
     DESC
-    
+
     s.homepage         = 'https://github.com/RxSwiftCommunity/RxFirebase'
     # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Arnaud Dorgans' => 'arnaud.dorgans@gmail.com' }
     s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxFirebase.git', :tag => s.version.to_s }
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
-    
-    s.cocoapods_version = '>= 1.4.0'
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.11'
+
+    s.cocoapods_version = '>= 1.10.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
 
     s.static_framework = true
     s.dependency 'RxSwift', '~> 5'
     s.dependency 'RxCocoa', '~> 5'
-    s.dependency 'FirebaseFunctions', '~> 2.5'
+    s.dependency 'FirebaseFunctions', '~> 7'
 
     s.source_files = 'Sources/Functions/**/*'
 end

--- a/RxFirebaseRemoteConfig.podspec
+++ b/RxFirebaseRemoteConfig.podspec
@@ -2,33 +2,33 @@ Pod::Spec.new do |s|
     s.name             = 'RxFirebaseRemoteConfig'
     s.version          = '0.3.8'
     s.summary          = 'RxSwift extensions for FirebaseFirestore.'
-    
+
     # This description is used to generate tags and improve search results.
     #   * Think: What does it do? Why did you write it? What is the focus?
     #   * Try to keep it short, snappy and to the point.
     #   * Write the description between the DESC delimiters below.
     #   * Finally, don't worry about the indent, CocoaPods strips it!
-    
+
     s.description      = <<-DESC
     RxSwift extensions for RxFirebaseRemoteConfig.
     DESC
-    
+
     s.homepage         = 'https://github.com/RxSwiftCommunity/RxFirebase'
     # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Arnaud Dorgans' => 'arnaud.dorgans@gmail.com' }
     s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxFirebase.git', :tag => s.version.to_s }
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
-    
-    s.cocoapods_version = '>= 1.4.0'
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.11'
+
+    s.cocoapods_version = '>= 1.10.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
 
     s.static_framework = true
     s.dependency 'RxSwift', '~> 5'
     s.dependency 'RxCocoa', '~> 5'
-    s.dependency 'FirebaseRemoteConfig', '~> 4'
+    s.dependency 'FirebaseRemoteConfig', '~> 7'
 
     s.source_files = 'Sources/RemoteConfig/**/*'
 end

--- a/RxFirebaseStorage.podspec
+++ b/RxFirebaseStorage.podspec
@@ -2,33 +2,33 @@ Pod::Spec.new do |s|
     s.name             = 'RxFirebaseStorage'
     s.version          = '0.3.8'
     s.summary          = 'RxSwift extensions for FirebaseStorage.'
-    
+
     # This description is used to generate tags and improve search results.
     #   * Think: What does it do? Why did you write it? What is the focus?
     #   * Try to keep it short, snappy and to the point.
     #   * Write the description between the DESC delimiters below.
     #   * Finally, don't worry about the indent, CocoaPods strips it!
-    
+
     s.description      = <<-DESC
     RxSwift extensions for FirebaseStorage.
     DESC
-    
+
     s.homepage         = 'https://github.com/RxSwiftCommunity/RxFirebase'
     # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
     s.license          = { :type => 'MIT', :file => 'LICENSE' }
     s.author           = { 'Arnaud Dorgans' => 'arnaud.dorgans@gmail.com' }
     s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxFirebase.git', :tag => s.version.to_s }
     # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
-    
-    s.cocoapods_version = '>= 1.4.0'
-    s.ios.deployment_target = '8.0'
-    s.osx.deployment_target = '10.11'
+
+    s.cocoapods_version = '>= 1.10.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '10.0'
 
     s.static_framework = true
     s.dependency 'RxSwift', '~> 5'
     s.dependency 'RxCocoa', '~> 5'
-    s.dependency 'FirebaseStorage', '~> 3'
+    s.dependency 'FirebaseStorage', '~> 7'
 
     s.source_files = 'Sources/Storage/**/*'
 end


### PR DESCRIPTION
The current firebase dependencies of RxFirebase is 6 and is outdated.

Breaking change: The minimum deployment target is changed due to the firebase 7 supports >= iOS 10.0.